### PR TITLE
Correctly record last_ip_address on order

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -21,10 +21,10 @@ module Spree
           @simple_current_order = find_order_by_token_or_user
 
           if @simple_current_order
-            @simple_current_order.last_ip_address = ip_address
+            @simple_current_order.update(last_ip_address: ip_address)
             return @simple_current_order
           else
-            @simple_current_order = Spree::Order.new
+            @simple_current_order = Spree::Order.new(last_ip_address: ip_address)
           end
         end
 
@@ -45,7 +45,7 @@ module Spree
           end
 
           if @current_order
-            @current_order.last_ip_address = ip_address
+            @current_order.update(last_ip_address: ip_address)
             return @current_order
           end
         end


### PR DESCRIPTION
The assignment of last_ip_address was not persisted where it was set.
When this module is included in a custom storefront, the assignment of
last_ip_address is lost. There was also a case in simple_current_order
where the last_ip_address was never assigned.


@bryanmtl can you merge? i need this fix for the fraud check. I cherry-pick the commit from https://github.com/solidusio/solidus/pull/1658